### PR TITLE
nsamples bug in `add_[predicted/fitted]_samples`

### DIFF
--- a/R/add_predicted_samples.R
+++ b/R/add_predicted_samples.R
@@ -161,17 +161,18 @@ predicted_samples.brmsfit = function(model, newdata, var = "pred", ..., n = NULL
   if (!requireNamespace("brms", quietly = TRUE)) {
     stop("The `brms` package is needed for `predicted_samples` to support `brmsfit` objects.", call. = FALSE)
   }
-  
-  if (hasArg(nsamples)) {
-    fitted_predicted_samples_brmsfit_(predict, model, newdata, var, ...,
-                                      re_formula = re_formula
-    )
+  fun_args = as.list(environment())
+  std_args = list(pass = list(f_fitted_predicted = predict, nsamples = n),
+                  names = c("n"))
+
+  if(any(names(std_args$pass) %in% names(list(...)))) {
+    warning("Use tidybayes add_predicted_samples arguments for",
+            " prediction methods. See function documentation for details.")
   }
-  else {
-    fitted_predicted_samples_brmsfit_(predict, model, newdata, var, ...,
-                                      nsamples = n, re_formula = re_formula
-    )
-  }
+  std_args$pass[names(list(...))] = list(...)
+  fun_args = fun_args[!(names(fun_args) %in% std_args$names)]
+
+  do.call(fitted_predicted_samples_brmsfit_, c(fun_args, std_args$pass))
 }
 
 #' @rdname add_predicted_samples

--- a/R/add_predicted_samples.R
+++ b/R/add_predicted_samples.R
@@ -161,10 +161,17 @@ predicted_samples.brmsfit = function(model, newdata, var = "pred", ..., n = NULL
   if (!requireNamespace("brms", quietly = TRUE)) {
     stop("The `brms` package is needed for `predicted_samples` to support `brmsfit` objects.", call. = FALSE)
   }
-
-  fitted_predicted_samples_brmsfit_(predict, model, newdata, var, ...,
-    nsamples = n, re_formula = re_formula
-  )
+  
+  if (hasArg(nsamples)) {
+    fitted_predicted_samples_brmsfit_(predict, model, newdata, var, ...,
+                                      re_formula = re_formula
+    )
+  }
+  else {
+    fitted_predicted_samples_brmsfit_(predict, model, newdata, var, ...,
+                                      nsamples = n, re_formula = re_formula
+    )
+  }
 }
 
 #' @rdname add_predicted_samples
@@ -193,10 +200,18 @@ fitted_samples.brmsfit = function(model, newdata, var = "estimate", ..., n = NUL
   names(dpars)[missing_names] = dpars[missing_names]
 
   # get the samples for the primary parameter first so we can stick the other estimates onto it
-  samples = fitted_predicted_samples_brmsfit_(
-    fitted, model, newdata, var, ...,
-    category = category, nsamples = n, re_formula = re_formula, dpar = NULL, scale = scale
-  )
+  if(hasArg(nsamples)) {
+    samples = fitted_predicted_samples_brmsfit_(
+      fitted, model, newdata, var, ...,
+      category = category, re_formula = re_formula, dpar = NULL, scale = scale
+    )
+  }
+  else {
+    samples = fitted_predicted_samples_brmsfit_(
+      fitted, model, newdata, var, ...,
+      category = category, nsamples = n, re_formula = re_formula, dpar = NULL, scale = scale
+    )
+  }
 
   for (i in seq_along(dpars)) {
     varname = names(dpars)[[i]]

--- a/tests/testthat/test.add_fitted_samples.R
+++ b/tests/testthat/test.add_fitted_samples.R
@@ -186,3 +186,28 @@ test_that("[add_]predicted_samples gives same results with standardized argument
   expect_equal(nrow(std_args_add), nrow(predict_args_add))
   expect_equal(std_args_add, predict_args_add)
 })
+
+test_that("[add_]predicted_samples gives same results with standardized arguments and prediction method arguments in rstanarm", {
+  m_hp_wt = readRDS("models.rstanarm.m_hp_wt.rds")
+  
+  set.seed(123)
+  std_args_fit = m_hp_wt %>%
+    fitted_samples(newdata = mtcars_tbl, n = 100)
+  set.seed(123)
+  std_args_add = m_hp_wt %>%
+    add_fitted_samples(newdata = mtcars_tbl, n = 100)
+  
+  set.seed(123)
+  predict_args_fit = m_hp_wt %>%
+    fitted_samples(newdata = mtcars_tbl, nsamples = 100)
+  set.seed(123)
+  predict_args_add = m_hp_wt %>%
+    add_fitted_samples(newdata = mtcars_tbl, nsamples = 100)
+  
+  expect_equal(nrow(std_args_fit), nrow(predict_args_fit))
+  expect_equal(std_args_fit, predict_args_fit)
+  
+  expect_equal(nrow(std_args_add), nrow(predict_args_add))
+  expect_equal(std_args_add, predict_args_add)
+})
+

--- a/tests/testthat/test.add_fitted_samples.R
+++ b/tests/testthat/test.add_fitted_samples.R
@@ -162,3 +162,27 @@ test_that("[add_]fitted_samples works on brms models with categorical outcomes (
   expect_equal(ref, fitted_samples(m_cyl_mpg, mtcars_tbl, scale = "linear"))
   expect_equal(ref, add_fitted_samples(mtcars_tbl, m_cyl_mpg, scale = "linear"))
 })
+
+test_that("[add_]predicted_samples gives same results with standardized arguments and prediction method arguments in brms", {
+  m_hp = readRDS("models.brms.m_hp.rds")
+  
+  set.seed(123)
+  std_args_fit <- m_hp %>%
+    fitted_samples(newdata = mtcars_tbl, n = 100)
+  set.seed(123)
+  std_args_add <- m_hp %>%
+    add_fitted_samples(newdata = mtcars_tbl, n = 100)
+  
+  set.seed(123)
+  predict_args_fit <- m_hp %>%
+    fitted_samples(newdata = mtcars_tbl, nsamples = 100)
+  set.seed(123)
+  predict_args_add <- m_hp %>%
+    add_fitted_samples(newdata = mtcars_tbl, nsamples = 100)
+  
+  expect_equal(nrow(std_args_fit), nrow(predict_args_fit))
+  expect_equal(std_args_fit, predict_args_fit)
+  
+  expect_equal(nrow(std_args_add), nrow(predict_args_add))
+  expect_equal(std_args_add, predict_args_add)
+})

--- a/tests/testthat/test.add_fitted_samples.R
+++ b/tests/testthat/test.add_fitted_samples.R
@@ -167,17 +167,17 @@ test_that("[add_]predicted_samples gives same results with standardized argument
   m_hp = readRDS("models.brms.m_hp.rds")
   
   set.seed(123)
-  std_args_fit <- m_hp %>%
+  std_args_fit = m_hp %>%
     fitted_samples(newdata = mtcars_tbl, n = 100)
   set.seed(123)
-  std_args_add <- m_hp %>%
+  std_args_add = m_hp %>%
     add_fitted_samples(newdata = mtcars_tbl, n = 100)
   
   set.seed(123)
-  predict_args_fit <- m_hp %>%
+  predict_args_fit = m_hp %>%
     fitted_samples(newdata = mtcars_tbl, nsamples = 100)
   set.seed(123)
-  predict_args_add <- m_hp %>%
+  predict_args_add = m_hp %>%
     add_fitted_samples(newdata = mtcars_tbl, nsamples = 100)
   
   expect_equal(nrow(std_args_fit), nrow(predict_args_fit))

--- a/tests/testthat/test.add_predicted_samples.R
+++ b/tests/testthat/test.add_predicted_samples.R
@@ -97,17 +97,17 @@ test_that("[add_]predicted_samples gives same results with standardized argument
   m_hp = readRDS("models.brms.m_hp.rds")
   
   set.seed(123)
-  std_args_pred <- m_hp %>%
+  std_args_pred = m_hp %>%
     predicted_samples(newdata = mtcars_tbl, n = 100)
   set.seed(123)
-  std_args_add <- m_hp %>%
+  std_args_add = m_hp %>%
     add_predicted_samples(newdata = mtcars_tbl, n = 100)
   
   set.seed(123)
-  predict_args_pred <- m_hp %>%
+  predict_args_pred = m_hp %>%
     predicted_samples(newdata = mtcars_tbl, nsamples = 100)
   set.seed(123)
-  predict_args_add <- m_hp %>%
+  predict_args_add = m_hp %>%
     add_predicted_samples(newdata = mtcars_tbl, nsamples = 100)
   
   expect_equal(nrow(std_args_pred), nrow(predict_args_pred))

--- a/tests/testthat/test.add_predicted_samples.R
+++ b/tests/testthat/test.add_predicted_samples.R
@@ -117,3 +117,27 @@ test_that("[add_]predicted_samples gives same results with standardized argument
   expect_equal(std_args_add, predict_args_add)
 })
 
+test_that("[add_]predicted_samples gives same results with standardized arguments and prediction method arguments in rstanarm", {
+  m_hp_wt = readRDS("models.rstanarm.m_hp_wt.rds")
+  
+  set.seed(123)
+  std_args_pred = m_hp_wt %>%
+    predicted_samples(newdata = mtcars_tbl, n = 100)
+  set.seed(123)
+  std_args_add = m_hp_wt %>%
+    add_predicted_samples(newdata = mtcars_tbl, n = 100)
+  
+  set.seed(123)
+  predict_args_pred = m_hp_wt %>%
+    predicted_samples(newdata = mtcars_tbl, nsamples = 100)
+  set.seed(123)
+  predict_args_add = m_hp_wt %>%
+    add_predicted_samples(newdata = mtcars_tbl, nsamples = 100)
+  
+  expect_equal(nrow(std_args_pred), nrow(predict_args_pred))
+  expect_equal(std_args_pred, predict_args_pred)
+  
+  expect_equal(nrow(std_args_add), nrow(predict_args_add))
+  expect_equal(std_args_add, predict_args_add)
+})
+

--- a/tests/testthat/test.add_predicted_samples.R
+++ b/tests/testthat/test.add_predicted_samples.R
@@ -93,15 +93,6 @@ test_that("[add_]predicted_samples works on a simple brms model", {
   expect_equal(ref, add_predicted_samples(mtcars_tbl, m_hp, seed = 123))
 })
 
-# Test Suite:
-# Test 1: "[add_]predicted_samples gives same results with standardized arguments
-#         "and prediction method arguments in rstanarm"
-# Test 2: "[add_]predicted_samples gives same results with standardized arguments
-#         "and prediction method arguments in brms"
-
-# can't use cmd-shift-t, or devtools::test()
-# need to use testthat::test_package("tidybayes")
-
 test_that("[add_]predicted_samples gives same results with standardized arguments and prediction method arguments in brms", {
   m_hp = readRDS("models.brms.m_hp.rds")
   

--- a/tests/testthat/test.add_predicted_samples.R
+++ b/tests/testthat/test.add_predicted_samples.R
@@ -92,3 +92,37 @@ test_that("[add_]predicted_samples works on a simple brms model", {
   set.seed(123)
   expect_equal(ref, add_predicted_samples(mtcars_tbl, m_hp, seed = 123))
 })
+
+# Test Suite:
+# Test 1: "[add_]predicted_samples gives same results with standardized arguments
+#         "and prediction method arguments in rstanarm"
+# Test 2: "[add_]predicted_samples gives same results with standardized arguments
+#         "and prediction method arguments in brms"
+
+# can't use cmd-shift-t, or devtools::test()
+# need to use testthat::test_package("tidybayes")
+
+test_that("[add_]predicted_samples gives same results with standardized arguments and prediction method arguments in brms", {
+  m_hp = readRDS("models.brms.m_hp.rds")
+  
+  set.seed(123)
+  std_args_pred <- m_hp %>%
+    predicted_samples(newdata = mtcars_tbl, n = 100)
+  set.seed(123)
+  std_args_add <- m_hp %>%
+    add_predicted_samples(newdata = mtcars_tbl, n = 100)
+  
+  set.seed(123)
+  predict_args_pred <- m_hp %>%
+    predicted_samples(newdata = mtcars_tbl, nsamples = 100)
+  set.seed(123)
+  predict_args_add <- m_hp %>%
+    add_predicted_samples(newdata = mtcars_tbl, nsamples = 100)
+  
+  expect_equal(nrow(std_args_pred), nrow(predict_args_pred))
+  expect_equal(std_args_pred, predict_args_pred)
+  
+  expect_equal(nrow(std_args_add), nrow(predict_args_add))
+  expect_equal(std_args_add, predict_args_add)
+})
+


### PR DESCRIPTION
Hey,

I found a bug with `add_[predicted/fitted]_samples`. The documentation says 

> ... Additional arguments passed to the underlying prediction method for the type of model given.

However, that doesn't work for every parameter of the underlying prediction method, which is confusing, as you'll see in the example below. The error comes from this:
```
Error in predict.brmsfit(model, newdata = newdata, summary = FALSE, ...) : 
   formal argument "nsamples" matched by multiple actual arguments
```
Here is the minimal example:
```
library(brms)
library(tidybayes)
library(modelr)

mod = brm(mpg ~ log(hp), data = mtcars, family = lognormal)
pred.data <- data_grid(mtcars, hp = seq_range(hp, n = 101))

# actual `brms` call
predict(mod, newdata=pred.data, nsamples = 100, summary = FALSE)

# Doesn't work
add_predicted_samples(model = mod, newdata = pred.data, nsamples = 100)
# Error in predict.brmsfit(model, newdata = newdata, summary = FALSE, ...) : 
#   formal argument "nsamples" matched by multiple actual arguments

# Works 
add_predicted_samples(model = mod, newdata = pred.data, n = 100)
# # A tibble: 10,100 x 5
# # Groups:   hp, .row [101]
#       hp  .row .chain .iteration     pred
#    <dbl> <int>  <int>      <int>    <dbl>
#  1    52     1     NA          1 29.39404
#  2    52     1     NA          2 26.98759
#  3    52     1     NA          3 24.98524
#  4    52     1     NA          4 36.79412
#  5    52     1     NA          5 36.18840
#  6    52     1     NA          6 34.22189
#  7    52     1     NA          7 33.07024
#  8    52     1     NA          8 36.53265
#  9    52     1     NA          9 34.32785
# 10    52     1     NA         10 38.18187
# # ... with 10,090 more rows

# Doesn't work
add_fitted_samples(model = mod, newdata = pred.data, nsamples = 100)
# Error in predict.brmsfit(model, newdata = newdata, summary = FALSE, ...) : 
#   formal argument "nsamples" matched by multiple actual arguments

# Works 
add_fitted_samples(model = mod, newdata = pred.data, n = 100)
```

I think I found the source of the error in `add_predicted_samples.R`. As you'll see in the diffs, if `nsamples` is included by the user in `...`, the code manually adds `nsamples = n` a second time, which throws an error. For example,
`predict(mod, newdata=pred.data, nsamples = 100, nsamples = NULL, summary = FALSE) `
gives the same error.

I found a method `hasArg()` that seems to do what we need, but I have to think there is a nicer way to fix this without if/else repeating almost the same code twice. 

Lastly, for the `fitted_samples.brmsfit` I suspect we'll also need a `hasArg()` check on `re_formula, dpar, scale` since those can also be passed by the user in `...`, but are explicitly set by the method
like `nsamples`. I haven't had time to test this yet, but the problem is here:
```
  samples = fitted_predicted_samples_brmsfit_(
    fitted, model, newdata, var, ...,
    category = category, nsamples = n, re_formula = re_formula, dpar = NULL, scale = scale
  )
```
And `re_formula, dpar, scale` are not given names here:
```
fitted_samples.brmsfit = function(model, newdata, var = "estimate", ..., n = NULL, re_formula = NULL,
  category = "category", auxpars = TRUE, scale = c("response", "linear")
```
Let me know your thoughts!