### PR TITLE
New error messages for standardized arguments in add_[fitted/predicted]_samples

### DIFF
--- a/R/add_predicted_samples.R
+++ b/R/add_predicted_samples.R
@@ -310,19 +310,20 @@ fitted_predicted_samples_brmsfit_ = function(f_fitted_predicted, model, newdata,
 }
 
 stop_on_non_generic_arg_ <- function(parent_dot_args_names, method_type, ...) {
-  # names of arguments passed in dot args of parent function
-  non_generic_names_passed = parent_dot_args_names[parent_dot_args_names %in% list(...)]
-  
-  stop(
-    paste(
-      c("`", non_generic_names_passed[1], 
-        "` is not supported in `",
-        method_type,
-        "`. Please use the generic argument `", 
-        names(list(...))[list(...) %in% non_generic_names_passed[1]],
-        "`. See the documentation for more details."
-        ), 
-      sep = ""
+  if (any(parent_dot_args_names %in% list(...))) {
+    non_generic_names_passed = parent_dot_args_names[parent_dot_args_names %in% list(...)]
+    
+    stop(
+      paste(
+        c("`", non_generic_names_passed[1], 
+          "` is not supported in `",
+          method_type,
+          "`. Please use the generic argument `", 
+          names(list(...))[list(...) %in% non_generic_names_passed[1]],
+          "`. See the documentation for more details."
+          ), 
+        sep = ""
+      )
     )
-  )
+  }
 }

--- a/R/add_predicted_samples.R
+++ b/R/add_predicted_samples.R
@@ -161,17 +161,18 @@ predicted_samples.brmsfit = function(model, newdata, var = "pred", ..., n = NULL
   if (!requireNamespace("brms", quietly = TRUE)) {
     stop("The `brms` package is needed for `predicted_samples` to support `brmsfit` objects.", call. = FALSE)
   }
-  
-  if (hasArg(nsamples)) {
-    fitted_predicted_samples_brmsfit_(predict, model, newdata, var, ...,
-                                      re_formula = re_formula
-    )
+  fun_args = as.list(environment())
+  std_args = list(pass = list(f_fitted_predicted = predict, nsamples = n),
+                  names = c("n"))
+
+  if(any(names(std_args$pass) %in% names(list(...)))) {
+    warning("Use tidybayes add_predicted_samples arguments for",
+            " prediction methods. See function documentation for details.")
   }
-  else {
-    fitted_predicted_samples_brmsfit_(predict, model, newdata, var, ...,
-                                      nsamples = n, re_formula = re_formula
-    )
-  }
+  std_args$pass[names(list(...))] = list(...)
+  fun_args = fun_args[!(names(fun_args) %in% std_args$names)]
+
+  do.call(fitted_predicted_samples_brmsfit_, c(fun_args, std_args$pass))
 }
 
 #' @rdname add_predicted_samples

--- a/R/add_predicted_samples.R
+++ b/R/add_predicted_samples.R
@@ -209,6 +209,10 @@ fitted_samples.brmsfit = function(model, newdata, var = "estimate", ..., n = NUL
     stop("`tidybayes` has standardized some arguments for [add_]fitted_samples",
          " Please use `n` rather than `nsamples`. See the documentation for",
          " more details.")  
+  } else if (hasArg(dpars)) {
+    stop("`tidybayes` has standardized some arguments for [add_]fitted_samples",
+         " Please use `auxpars` rather than `dpars`. See the documentation for",
+         " more details.") 
   }
   
   # get the names of distributional regression parameters to include
@@ -219,7 +223,7 @@ fitted_samples.brmsfit = function(model, newdata, var = "estimate", ..., n = NUL
   } else {
     auxpars
   }
-
+  
   # missing names default to the same name used for the parameter in the model
   missing_names = is.null(names(dpars))
   names(dpars)[missing_names] = dpars[missing_names]

--- a/R/add_predicted_samples.R
+++ b/R/add_predicted_samples.R
@@ -320,7 +320,7 @@ stop_on_non_generic_arg_ <- function(parent_dot_args_names, method_type, ...) {
           method_type,
           "`. Please use the generic argument `", 
           names(list(...))[list(...) %in% non_generic_names_passed[1]],
-          "`. See the documentation for more details."
+          "`. See the documentation for additional details."
           ), 
         sep = ""
       )

--- a/R/add_predicted_samples.R
+++ b/R/add_predicted_samples.R
@@ -161,10 +161,17 @@ predicted_samples.brmsfit = function(model, newdata, var = "pred", ..., n = NULL
   if (!requireNamespace("brms", quietly = TRUE)) {
     stop("The `brms` package is needed for `predicted_samples` to support `brmsfit` objects.", call. = FALSE)
   }
-
-  fitted_predicted_samples_brmsfit_(predict, model, newdata, var, ...,
-    nsamples = n, re_formula = re_formula
-  )
+  
+  if (hasArg(nsamples)) {
+    fitted_predicted_samples_brmsfit_(predict, model, newdata, var, ...,
+                                      re_formula = re_formula
+    )
+  }
+  else {
+    fitted_predicted_samples_brmsfit_(predict, model, newdata, var, ...,
+                                      nsamples = n, re_formula = re_formula
+    )
+  }
 }
 
 #' @rdname add_predicted_samples
@@ -193,10 +200,18 @@ fitted_samples.brmsfit = function(model, newdata, var = "estimate", ..., n = NUL
   names(dpars)[missing_names] = dpars[missing_names]
 
   # get the samples for the primary parameter first so we can stick the other estimates onto it
-  samples = fitted_predicted_samples_brmsfit_(
-    fitted, model, newdata, var, ...,
-    category = category, nsamples = n, re_formula = re_formula, dpar = NULL, scale = scale
-  )
+  if(hasArg(nsamples)) {
+    samples = fitted_predicted_samples_brmsfit_(
+      fitted, model, newdata, var, ...,
+      category = category, re_formula = re_formula, dpar = NULL, scale = scale
+    )
+  }
+  else {
+    samples = fitted_predicted_samples_brmsfit_(
+      fitted, model, newdata, var, ...,
+      category = category, nsamples = n, re_formula = re_formula, dpar = NULL, scale = scale
+    )
+  }
 
   for (i in seq_along(dpars)) {
     varname = names(dpars)[[i]]

--- a/R/add_predicted_samples.R
+++ b/R/add_predicted_samples.R
@@ -126,15 +126,9 @@ predicted_samples.stanreg = function(model, newdata, var = "pred", ..., n = NULL
     stop("The `rstantools` package is needed for `predicted_samples` to support `stanreg` objects.", call. = FALSE)
   }
   
-  if (hasArg(draws)) { # See https://github.com/mjskay/tidybayes/issues/70
-    stop("`tidybayes` has standardized some arguments for [add_]predicted_samples",
-         " Please use `n` rather than `draws`. See the documentation for",
-         " more details.")
-  } else if (hasArg(re.form)) {
-    stop("`tidybayes` has standardized some arguments for [add_]predicted_samples",
-         " Please use `re_formula` rather than `re.form`. See the documentation for",
-         " more details.")
-  }
+  stop_on_non_generic_arg_(
+    names(list(...)), "[add_]predicted_samples", n = "draws", re_formula = "re.form"
+  )
   
   fitted_predicted_samples_brmsfit_(rstantools::posterior_predict, model, newdata, var, ...,
     draws = n, re.form = re_formula, is_brms = FALSE
@@ -152,15 +146,9 @@ fitted_samples.stanreg = function(model, newdata, var = "estimate", ..., n = NUL
     stop("The `rstanarm` package is needed for `fitted_samples` to support `stanreg` objects.", call. = FALSE)
   }
   
-  if (hasArg(re.form)) {
-    stop("`tidybayes` has standardized some arguments for [add_]fitted_samples",
-         " Please use `re_formula` rather than `re.form`. See the documentation for",
-         " more details.")
-  } else if (hasArg(transform)) {
-    stop("`tidybayes` has standardized some arguments for [add_]fitted_samples",
-         " Please use `scale` rather than `transform`. See the documentation for",
-         " more details.")
-  }
+  stop_on_non_generic_arg_(
+    names(list(...)), "[add_]predicted_samples", re_formula = "re.form", scale = "transform"
+  )
   
   samples = fitted_predicted_samples_brmsfit_(rstanarm::posterior_linpred, model, newdata, var, ...,
     category = category, re.form = re_formula, transform = transform, is_brms = FALSE
@@ -181,17 +169,11 @@ predicted_samples.brmsfit = function(model, newdata, var = "pred", ..., n = NULL
   if (!requireNamespace("brms", quietly = TRUE)) {
     stop("The `brms` package is needed for `predicted_samples` to support `brmsfit` objects.", call. = FALSE)
   }
-  # testfind
   
   stop_on_non_generic_arg_(
     names(list(...)), "[add_]predicted_samples", n = "nsamples"
   )
-  # if (hasArg(nsamples)) {
-  #   stop("`tidybayes` has standardized some arguments for [add_]predicted_samples.",
-  #        " Please use `n` rather than `nsamples`. See the documentation for",
-  #        " more details.", call. = FALSE)
-  # }
-  
+
   fitted_predicted_samples_brmsfit_(predict, model, newdata, var, ...,
     nsamples = n, re_formula = re_formula
   )
@@ -208,16 +190,10 @@ fitted_samples.brmsfit = function(model, newdata, var = "estimate", ..., n = NUL
   if (!requireNamespace("brms", quietly = TRUE)) {
     stop("The `brms` package is needed for `fitted_samples` to support `brmsfit` objects.", call. = FALSE)
   }
-
-  if(hasArg(nsamples)) {
-    stop("`tidybayes` has standardized some arguments for [add_]fitted_samples",
-         " Please use `n` rather than `nsamples`. See the documentation for",
-         " more details.")  
-  } else if (hasArg(dpars)) {
-    stop("`tidybayes` has standardized some arguments for [add_]fitted_samples",
-         " Please use `auxpars` rather than `dpars`. See the documentation for",
-         " more details.") 
-  }
+  
+  stop_on_non_generic_arg_(
+    names(list(...)), "[add_]fitted_samples", n = "nsamples", auxpars = "dpars"
+  )
   
   # get the names of distributional regression parameters to include
   dpars = if (is_true(auxpars)) {

--- a/R/add_predicted_samples.R
+++ b/R/add_predicted_samples.R
@@ -181,12 +181,16 @@ predicted_samples.brmsfit = function(model, newdata, var = "pred", ..., n = NULL
   if (!requireNamespace("brms", quietly = TRUE)) {
     stop("The `brms` package is needed for `predicted_samples` to support `brmsfit` objects.", call. = FALSE)
   }
+  # testfind
   
-  if (hasArg(nsamples)) { # See https://github.com/mjskay/tidybayes/issues/70
-    stop("`tidybayes` has standardized some arguments for [add_]predicted_samples",
-         " Please use `n` rather than `nsamples`. See the documentation for",
-         " more details.")
-  }
+  stop_on_non_generic_arg_(
+    names(list(...)), "[add_]predicted_samples", n = "nsamples"
+  )
+  # if (hasArg(nsamples)) {
+  #   stop("`tidybayes` has standardized some arguments for [add_]predicted_samples.",
+  #        " Please use `n` rather than `nsamples`. See the documentation for",
+  #        " more details.", call. = FALSE)
+  # }
   
   fitted_predicted_samples_brmsfit_(predict, model, newdata, var, ...,
     nsamples = n, re_formula = re_formula
@@ -303,4 +307,22 @@ fitted_predicted_samples_brmsfit_ = function(f_fitted_predicted, model, newdata,
     inner_join(fits_preds_df, by = ".row") %>%
     select(-!!sym(var), !!sym(var)) %>%
     group_by(!!!syms(groups))
+}
+
+stop_on_non_generic_arg_ <- function(parent_dot_args_names, method_type, ...) {
+  # names of arguments passed in dot args of parent function
+  non_generic_names_passed = parent_dot_args_names[parent_dot_args_names %in% list(...)]
+  
+  stop(
+    paste(
+      c("`", non_generic_names_passed[1], 
+        "` is not supported in `",
+        method_type,
+        "`. Please use the generic argument `", 
+        names(list(...))[list(...) %in% non_generic_names_passed[1]],
+        "`. See the documentation for more details."
+        ), 
+      sep = ""
+    )
+  )
 }

--- a/R/add_predicted_samples.R
+++ b/R/add_predicted_samples.R
@@ -161,18 +161,16 @@ predicted_samples.brmsfit = function(model, newdata, var = "pred", ..., n = NULL
   if (!requireNamespace("brms", quietly = TRUE)) {
     stop("The `brms` package is needed for `predicted_samples` to support `brmsfit` objects.", call. = FALSE)
   }
-  fun_args = as.list(environment())
-  std_args = list(pass = list(f_fitted_predicted = predict, nsamples = n),
-                  names = c("n"))
-
-  if(any(names(std_args$pass) %in% names(list(...)))) {
-    warning("Use tidybayes add_predicted_samples arguments for",
-            " prediction methods. See function documentation for details.")
+  
+  if (hasArg(nsamples)) { # See https://github.com/mjskay/tidybayes/issues/70
+    stop("`tidybayes` has standardized some arguments for [add_]predicted_samples",
+         " Please use `n` rather than `nsamples`. See the documentation for",
+         " more details.")
   }
-  std_args$pass[names(list(...))] = list(...)
-  fun_args = fun_args[!(names(fun_args) %in% std_args$names)]
-
-  do.call(fitted_predicted_samples_brmsfit_, c(fun_args, std_args$pass))
+  
+  fitted_predicted_samples_brmsfit_(predict, model, newdata, var, ...,
+                                    nsamples = n, re_formula = re_formula
+  )
 }
 
 #' @rdname add_predicted_samples
@@ -202,17 +200,16 @@ fitted_samples.brmsfit = function(model, newdata, var = "estimate", ..., n = NUL
 
   # get the samples for the primary parameter first so we can stick the other estimates onto it
   if(hasArg(nsamples)) {
-    samples = fitted_predicted_samples_brmsfit_(
-      fitted, model, newdata, var, ...,
-      category = category, re_formula = re_formula, dpar = NULL, scale = scale
-    )
+    stop("`tidybayes` has standardized some arguments for [add_]fitted_samples",
+         " Please use `n` rather than `nsamples`. See the documentation for",
+         " more details.")  
   }
-  else {
-    samples = fitted_predicted_samples_brmsfit_(
-      fitted, model, newdata, var, ...,
-      category = category, nsamples = n, re_formula = re_formula, dpar = NULL, scale = scale
-    )
-  }
+  
+  samples = fitted_predicted_samples_brmsfit_(
+    fitted, model, newdata, var, ...,
+    category = category, nsamples = n, re_formula = re_formula, dpar = NULL, scale = scale
+  )
+
 
   for (i in seq_along(dpars)) {
     varname = names(dpars)[[i]]

--- a/R/add_predicted_samples.R
+++ b/R/add_predicted_samples.R
@@ -147,7 +147,7 @@ fitted_samples.stanreg = function(model, newdata, var = "estimate", ..., n = NUL
   }
   
   stop_on_non_generic_arg_(
-    names(list(...)), "[add_]predicted_samples", re_formula = "re.form", scale = "transform"
+    names(list(...)), "[add_]fitted_samples", re_formula = "re.form", scale = "transform"
   )
   
   samples = fitted_predicted_samples_brmsfit_(rstanarm::posterior_linpred, model, newdata, var, ...,

--- a/R/add_predicted_samples.R
+++ b/R/add_predicted_samples.R
@@ -125,7 +125,13 @@ predicted_samples.stanreg = function(model, newdata, var = "pred", ..., n = NULL
   if (!requireNamespace("rstantools", quietly = TRUE)) {
     stop("The `rstantools` package is needed for `predicted_samples` to support `stanreg` objects.", call. = FALSE)
   }
-
+  
+  if (hasArg(draws)) { # See https://github.com/mjskay/tidybayes/issues/70
+    stop("`tidybayes` has standardized some arguments for [add_]predicted_samples",
+         " Please use `n` rather than `draws`. See the documentation for",
+         " more details.")
+  }
+  
   fitted_predicted_samples_brmsfit_(rstantools::posterior_predict, model, newdata, var, ...,
     draws = n, re.form = re_formula, is_brms = FALSE
   )
@@ -141,7 +147,7 @@ fitted_samples.stanreg = function(model, newdata, var = "estimate", ..., n = NUL
   if (!requireNamespace("rstanarm", quietly = TRUE)) {
     stop("The `rstanarm` package is needed for `fitted_samples` to support `stanreg` objects.", call. = FALSE)
   }
-
+  
   samples = fitted_predicted_samples_brmsfit_(rstanarm::posterior_linpred, model, newdata, var, ...,
     category = category, re.form = re_formula, transform = transform, is_brms = FALSE
   )
@@ -185,6 +191,12 @@ fitted_samples.brmsfit = function(model, newdata, var = "estimate", ..., n = NUL
     stop("The `brms` package is needed for `fitted_samples` to support `brmsfit` objects.", call. = FALSE)
   }
 
+  if(hasArg(nsamples)) {
+    stop("`tidybayes` has standardized some arguments for [add_]fitted_samples",
+         " Please use `n` rather than `nsamples`. See the documentation for",
+         " more details.")  
+  }
+  
   # get the names of distributional regression parameters to include
   dpars = if (is_true(auxpars)) {
     names(model$formula$pforms)
@@ -199,12 +211,7 @@ fitted_samples.brmsfit = function(model, newdata, var = "estimate", ..., n = NUL
   names(dpars)[missing_names] = dpars[missing_names]
 
   # get the samples for the primary parameter first so we can stick the other estimates onto it
-  if(hasArg(nsamples)) {
-    stop("`tidybayes` has standardized some arguments for [add_]fitted_samples",
-         " Please use `n` rather than `nsamples`. See the documentation for",
-         " more details.")  
-  }
-  
+
   samples = fitted_predicted_samples_brmsfit_(
     fitted, model, newdata, var, ...,
     category = category, nsamples = n, re_formula = re_formula, dpar = NULL, scale = scale

--- a/R/add_predicted_samples.R
+++ b/R/add_predicted_samples.R
@@ -156,6 +156,10 @@ fitted_samples.stanreg = function(model, newdata, var = "estimate", ..., n = NUL
     stop("`tidybayes` has standardized some arguments for [add_]fitted_samples",
          " Please use `re_formula` rather than `re.form`. See the documentation for",
          " more details.")
+  } else if (hasArg(transform)) {
+    stop("`tidybayes` has standardized some arguments for [add_]fitted_samples",
+         " Please use `scale` rather than `transform`. See the documentation for",
+         " more details.")
   }
   
   samples = fitted_predicted_samples_brmsfit_(rstanarm::posterior_linpred, model, newdata, var, ...,

--- a/R/add_predicted_samples.R
+++ b/R/add_predicted_samples.R
@@ -189,7 +189,7 @@ predicted_samples.brmsfit = function(model, newdata, var = "pred", ..., n = NULL
   }
   
   fitted_predicted_samples_brmsfit_(predict, model, newdata, var, ...,
-                                    nsamples = n, re_formula = re_formula
+    nsamples = n, re_formula = re_formula
   )
 }
 

--- a/R/add_predicted_samples.R
+++ b/R/add_predicted_samples.R
@@ -130,6 +130,10 @@ predicted_samples.stanreg = function(model, newdata, var = "pred", ..., n = NULL
     stop("`tidybayes` has standardized some arguments for [add_]predicted_samples",
          " Please use `n` rather than `draws`. See the documentation for",
          " more details.")
+  } else if (hasArg(re.form)) {
+    stop("`tidybayes` has standardized some arguments for [add_]predicted_samples",
+         " Please use `re_formula` rather than `re.form`. See the documentation for",
+         " more details.")
   }
   
   fitted_predicted_samples_brmsfit_(rstantools::posterior_predict, model, newdata, var, ...,
@@ -146,6 +150,12 @@ fitted_samples.stanreg = function(model, newdata, var = "estimate", ..., n = NUL
 
   if (!requireNamespace("rstanarm", quietly = TRUE)) {
     stop("The `rstanarm` package is needed for `fitted_samples` to support `stanreg` objects.", call. = FALSE)
+  }
+  
+  if (hasArg(re.form)) {
+    stop("`tidybayes` has standardized some arguments for [add_]fitted_samples",
+         " Please use `re_formula` rather than `re.form`. See the documentation for",
+         " more details.")
   }
   
   samples = fitted_predicted_samples_brmsfit_(rstanarm::posterior_linpred, model, newdata, var, ...,

--- a/tests/testthat/test.add_fitted_samples.R
+++ b/tests/testthat/test.add_fitted_samples.R
@@ -128,10 +128,14 @@ test_that("[add_]fitted_samples works on brms models with auxpars", {
 test_that("[add_]fitted_samples throws an when dpars is called instead of auxpars on brms models with auxpars", {
   m_hp_sigma = readRDS("models.brms.m_hp_sigma.rds")
   
-  expect_error(fitted_samples(m_hp_sigma, mtcars_tbl, dpars = "sigma"),
-               "`dpars.*.See the documentation for additional details.")
-  expect_error(add_fitted_samples(mtcars_tbl, m_hp_sigma, dpars = "sigma"),
-               "`dpars.*.See the documentation for additional details.")
+  expect_error(
+    fitted_samples(m_hp_sigma, mtcars_tbl, dpars = "sigma"),
+    "`dpars.*.`auxpars`.*.See the documentation for additional details."
+  )
+  expect_error(
+    add_fitted_samples(mtcars_tbl, m_hp_sigma, dpars = "sigma"),
+    "`dpars.*.`auxpars`.*.See the documentation for additional details."
+  )
 })
 
 
@@ -175,10 +179,14 @@ test_that("[add_]fitted_samples works on brms models with categorical outcomes (
 test_that("[add_]fitted_samples throws an error when nsamples is called instead of n in brms", {
   m_hp = readRDS("models.brms.m_hp.rds")
   
-  expect_error(m_hp %>% fitted_samples(newdata = mtcars_tbl, nsamples = 100),
-               "`nsamples.*.See the documentation for additional details.")
-  expect_error(m_hp %>% add_fitted_samples(newdata = mtcars_tbl, nsamples = 100),
-               "`nsamples.*.See the documentation for additional details.")
+  expect_error(
+    m_hp %>% fitted_samples(newdata = mtcars_tbl, nsamples = 100),
+    "`nsamples.*.`n`.*.See the documentation for additional details."
+  )
+  expect_error(
+    m_hp %>% add_fitted_samples(newdata = mtcars_tbl, nsamples = 100),
+    "`nsamples.*.`n`.*.See the documentation for additional details."
+  )
 })
 
 # rstanarm doesn't have a draws method for fitted samples
@@ -186,17 +194,25 @@ test_that("[add_]fitted_samples throws an error when nsamples is called instead 
 test_that("[add_]predicted_samples throws an error when re.form is called instead of re_formula in rstanarm", {
   m_hp_wt = readRDS("models.rstanarm.m_hp_wt.rds")
   
-  expect_error(m_hp_wt %>% fitted_samples(newdata = mtcars_tbl, re.form = NULL),
-               "`re.form.*.See the documentation for additional details.")
-  expect_error(m_hp_wt %>% add_fitted_samples(newdata = mtcars_tbl, re.form = NULL),
-               "`re.form.*.See the documentation for additional details.")
+  expect_error(
+    m_hp_wt %>% fitted_samples(newdata = mtcars_tbl, re.form = NULL),
+    "`re.form.*.`re_formula`.*.See the documentation for additional details."
+  )
+  expect_error(
+    m_hp_wt %>% add_fitted_samples(newdata = mtcars_tbl, re.form = NULL),
+    "`re.form.*.`re_formula`.*.See the documentation for additional details."
+  )
 })
 
 test_that("[add_]predicted_samples throws an error when transform is called instead of scale in rstanarm", {
   m_hp_wt = readRDS("models.rstanarm.m_hp_wt.rds")
   
-  expect_error(m_hp_wt %>% fitted_samples(newdata = mtcars_tbl, transform = TRUE),
-               "`transform.*.See the documentation for additional details.")
-  expect_error(m_hp_wt %>% add_fitted_samples(newdata = mtcars_tbl, transform = TRUE),
-               "`transform.*.See the documentation for additional details.")
+  expect_error(
+    m_hp_wt %>% fitted_samples(newdata = mtcars_tbl, transform = TRUE),
+    "`transform.*.`scale`.*.See the documentation for additional details."
+  )
+  expect_error(
+    m_hp_wt %>% add_fitted_samples(newdata = mtcars_tbl, transform = TRUE), 
+    "`transform.*.`scale`.*.See the documentation for additional details."
+  )
 })

--- a/tests/testthat/test.add_fitted_samples.R
+++ b/tests/testthat/test.add_fitted_samples.R
@@ -129,9 +129,9 @@ test_that("[add_]fitted_samples throws an when dpars is called instead of auxpar
   m_hp_sigma = readRDS("models.brms.m_hp_sigma.rds")
   
   expect_error(fitted_samples(m_hp_sigma, mtcars_tbl, dpars = "sigma"),
-               ".See the documentation for additional details.")
+               "`dpars.*.See the documentation for additional details.")
   expect_error(add_fitted_samples(mtcars_tbl, m_hp_sigma, dpars = "sigma"),
-               ".See the documentation for additional details.")
+               "`dpars.*.See the documentation for additional details.")
 })
 
 
@@ -176,9 +176,9 @@ test_that("[add_]fitted_samples throws an error when nsamples is called instead 
   m_hp = readRDS("models.brms.m_hp.rds")
   
   expect_error(m_hp %>% fitted_samples(newdata = mtcars_tbl, nsamples = 100),
-               ".See the documentation for additional details.")
+               "`nsamples.*.See the documentation for additional details.")
   expect_error(m_hp %>% add_fitted_samples(newdata = mtcars_tbl, nsamples = 100),
-               ".See the documentation for additional details.")
+               "`nsamples.*.See the documentation for additional details.")
 })
 
 # rstanarm doesn't have a draws method for fitted samples
@@ -187,16 +187,16 @@ test_that("[add_]predicted_samples throws an error when re.form is called instea
   m_hp_wt = readRDS("models.rstanarm.m_hp_wt.rds")
   
   expect_error(m_hp_wt %>% fitted_samples(newdata = mtcars_tbl, re.form = NULL),
-               ".See the documentation for additional details.")
+               "`re.form.*.See the documentation for additional details.")
   expect_error(m_hp_wt %>% add_fitted_samples(newdata = mtcars_tbl, re.form = NULL),
-               ".See the documentation for additional details.")
+               "`re.form.*.See the documentation for additional details.")
 })
 
 test_that("[add_]predicted_samples throws an error when transform is called instead of scale in rstanarm", {
   m_hp_wt = readRDS("models.rstanarm.m_hp_wt.rds")
   
   expect_error(m_hp_wt %>% fitted_samples(newdata = mtcars_tbl, transform = TRUE),
-               ".See the documentation for additional details.")
+               "`transform.*.See the documentation for additional details.")
   expect_error(m_hp_wt %>% add_fitted_samples(newdata = mtcars_tbl, transform = TRUE),
-               ".See the documentation for additional details.")
+               "`transform.*.See the documentation for additional details.")
 })

--- a/tests/testthat/test.add_fitted_samples.R
+++ b/tests/testthat/test.add_fitted_samples.R
@@ -172,11 +172,4 @@ test_that("[add_]fitted_samples throws an error when nsamples is called instead 
                "`tidybayes`.*")
 })
 
-test_that("[add_]fitted_samples throws an error when draws is called instead of n in rstanarm", {
-  m_hp_wt = readRDS("models.rstanarm.m_hp_wt.rds")
-  
-  expect_error(m_hp_wt %>% fitted_samples(newdata = mtcars_tbl, draws = 100),
-               "`tidybayes`*")
-  expect_error(m_hp_wt %>% add_fitted_samples(newdata = mtcars_tbl, draws = 100),
-               "`tidybayes`*")
-})
+# rstanarm doesn't have a draws method for fitted samples

--- a/tests/testthat/test.add_fitted_samples.R
+++ b/tests/testthat/test.add_fitted_samples.R
@@ -186,3 +186,28 @@ test_that("[add_]predicted_samples gives same results with standardized argument
   expect_equal(nrow(std_args_add), nrow(predict_args_add))
   expect_equal(std_args_add, predict_args_add)
 })
+
+test_that("[add_]predicted_samples gives same results with standardized arguments and prediction method arguments in rstanarm", {
+  m_hp_wt = readRDS("models.rstanarm.m_hp_wt.rds")
+  
+  set.seed(123)
+  std_args_fit = m_hp_wt %>%
+    fitted_samples(newdata = mtcars_tbl, n = 100)
+  set.seed(123)
+  std_args_add = m_hp_wt %>%
+    add_fitted_samples(newdata = mtcars_tbl, n = 100)
+  
+  set.seed(123)
+  predict_args_fit = m_hp_wt %>%
+    fitted_samples(newdata = mtcars_tbl, nsamples = 100)
+  set.seed(123)
+  predict_args_add = m_hp_wt %>%
+    add_fitted_samples(newdata = mtcars_tbl, nsamples = 100)
+  
+  expect_equal(nrow(std_args_fit), nrow(predict_args_fit))
+  expect_equal(std_args_fit, predict_args_fit)
+  
+  expect_equal(nrow(std_args_add), nrow(predict_args_add))
+  expect_equal(std_args_add, predict_args_add)
+})
+

--- a/tests/testthat/test.add_fitted_samples.R
+++ b/tests/testthat/test.add_fitted_samples.R
@@ -162,3 +162,27 @@ test_that("[add_]fitted_samples works on brms models with categorical outcomes (
   expect_equal(ref, fitted_samples(m_cyl_mpg, mtcars_tbl, scale = "linear"))
   expect_equal(ref, add_fitted_samples(mtcars_tbl, m_cyl_mpg, scale = "linear"))
 })
+
+test_that("[add_]predicted_samples gives same results with standardized arguments and prediction method arguments in brms", {
+  m_hp = readRDS("models.brms.m_hp.rds")
+  
+  set.seed(123)
+  std_args_fit <- m_hp %>%
+    fitted_samples(newdata = mtcars_tbl, n = 100)
+  set.seed(123)
+  std_args_add <- m_hp %>%
+    add_fitted_samples(newdata = mtcars_tbl, n = 100)
+  
+  set.seed(123)
+  predict_args_fit <- m_hp %>%
+    fitted_samples(newdata = mtcars_tbl, nsamples = 100)
+  set.seed(123)
+  predict_args_add <- m_hp %>%
+    add_fitted_samples(newdata = mtcars_tbl, nsamples = 100)
+  
+  expect_equal(nrow(std_args_fit), nrow(predict_args_fit))
+  expect_equal(std_args_fit, predict_args_fit)
+  
+  expect_equal(nrow(std_args_add), nrow(predict_args_add))
+  expect_equal(std_args_add, predict_args_add)
+})

--- a/tests/testthat/test.add_fitted_samples.R
+++ b/tests/testthat/test.add_fitted_samples.R
@@ -173,3 +173,13 @@ test_that("[add_]fitted_samples throws an error when nsamples is called instead 
 })
 
 # rstanarm doesn't have a draws method for fitted samples
+
+test_that("[add_]predicted_samples throws an error when re.form is called instead of re_formula in rstanarm", {
+  m_hp_wt = readRDS("models.rstanarm.m_hp_wt.rds")
+  
+  expect_error(m_hp_wt %>% fitted_samples(newdata = mtcars_tbl, re.form = NULL),
+               "`tidybayes`*")
+  expect_error(m_hp_wt %>% add_fitted_samples(newdata = mtcars_tbl, re.form = NULL),
+               "`tidybayes`*")
+})
+

--- a/tests/testthat/test.add_fitted_samples.R
+++ b/tests/testthat/test.add_fitted_samples.R
@@ -129,9 +129,9 @@ test_that("[add_]fitted_samples throws an when dpars is called instead of auxpar
   m_hp_sigma = readRDS("models.brms.m_hp_sigma.rds")
   
   expect_error(fitted_samples(m_hp_sigma, mtcars_tbl, dpars = "sigma"),
-               "`tidybayes`.*")
+               ".See the documentation for additional details.")
   expect_error(add_fitted_samples(mtcars_tbl, m_hp_sigma, dpars = "sigma"),
-               "`tidybayes`.*")
+               ".See the documentation for additional details.")
 })
 
 

--- a/tests/testthat/test.add_fitted_samples.R
+++ b/tests/testthat/test.add_fitted_samples.R
@@ -176,9 +176,9 @@ test_that("[add_]fitted_samples throws an error when nsamples is called instead 
   m_hp = readRDS("models.brms.m_hp.rds")
   
   expect_error(m_hp %>% fitted_samples(newdata = mtcars_tbl, nsamples = 100),
-               "`tidybayes`.*")
+               ".See the documentation for additional details.")
   expect_error(m_hp %>% add_fitted_samples(newdata = mtcars_tbl, nsamples = 100),
-               "`tidybayes`.*")
+               ".See the documentation for additional details.")
 })
 
 # rstanarm doesn't have a draws method for fitted samples
@@ -187,16 +187,16 @@ test_that("[add_]predicted_samples throws an error when re.form is called instea
   m_hp_wt = readRDS("models.rstanarm.m_hp_wt.rds")
   
   expect_error(m_hp_wt %>% fitted_samples(newdata = mtcars_tbl, re.form = NULL),
-               "`tidybayes`*")
+               ".See the documentation for additional details.")
   expect_error(m_hp_wt %>% add_fitted_samples(newdata = mtcars_tbl, re.form = NULL),
-               "`tidybayes`*")
+               ".See the documentation for additional details.")
 })
 
 test_that("[add_]predicted_samples throws an error when transform is called instead of scale in rstanarm", {
   m_hp_wt = readRDS("models.rstanarm.m_hp_wt.rds")
   
   expect_error(m_hp_wt %>% fitted_samples(newdata = mtcars_tbl, transform = TRUE),
-               "`tidybayes`*")
+               ".See the documentation for additional details.")
   expect_error(m_hp_wt %>% add_fitted_samples(newdata = mtcars_tbl, transform = TRUE),
-               "`tidybayes`*")
+               ".See the documentation for additional details.")
 })

--- a/tests/testthat/test.add_fitted_samples.R
+++ b/tests/testthat/test.add_fitted_samples.R
@@ -163,51 +163,20 @@ test_that("[add_]fitted_samples works on brms models with categorical outcomes (
   expect_equal(ref, add_fitted_samples(mtcars_tbl, m_cyl_mpg, scale = "linear"))
 })
 
-test_that("[add_]predicted_samples gives same results with standardized arguments and prediction method arguments in brms", {
+test_that("[add_]fitted_samples throws an error when nsamples is called instead of n in brms", {
   m_hp = readRDS("models.brms.m_hp.rds")
   
-  set.seed(123)
-  std_args_fit = m_hp %>%
-    fitted_samples(newdata = mtcars_tbl, n = 100)
-  set.seed(123)
-  std_args_add = m_hp %>%
-    add_fitted_samples(newdata = mtcars_tbl, n = 100)
-  
-  set.seed(123)
-  predict_args_fit = m_hp %>%
-    fitted_samples(newdata = mtcars_tbl, nsamples = 100)
-  set.seed(123)
-  predict_args_add = m_hp %>%
-    add_fitted_samples(newdata = mtcars_tbl, nsamples = 100)
-  
-  expect_equal(nrow(std_args_fit), nrow(predict_args_fit))
-  expect_equal(std_args_fit, predict_args_fit)
-  
-  expect_equal(nrow(std_args_add), nrow(predict_args_add))
-  expect_equal(std_args_add, predict_args_add)
+  expect_error(m_hp %>% fitted_samples(newdata = mtcars_tbl, nsamples = 100),
+               "`tidybayes`.*")
+  expect_error(m_hp %>% add_fitted_samples(newdata = mtcars_tbl, nsamples = 100),
+               "`tidybayes`.*")
 })
 
-test_that("[add_]predicted_samples gives same results with standardized arguments and prediction method arguments in rstanarm", {
+test_that("[add_]fitted_samples throws an error when draws is called instead of n in rstanarm", {
   m_hp_wt = readRDS("models.rstanarm.m_hp_wt.rds")
   
-  set.seed(123)
-  std_args_fit = m_hp_wt %>%
-    fitted_samples(newdata = mtcars_tbl, n = 100)
-  set.seed(123)
-  std_args_add = m_hp_wt %>%
-    add_fitted_samples(newdata = mtcars_tbl, n = 100)
-  
-  set.seed(123)
-  predict_args_fit = m_hp_wt %>%
-    fitted_samples(newdata = mtcars_tbl, nsamples = 100)
-  set.seed(123)
-  predict_args_add = m_hp_wt %>%
-    add_fitted_samples(newdata = mtcars_tbl, nsamples = 100)
-  
-  expect_equal(nrow(std_args_fit), nrow(predict_args_fit))
-  expect_equal(std_args_fit, predict_args_fit)
-  
-  expect_equal(nrow(std_args_add), nrow(predict_args_add))
-  expect_equal(std_args_add, predict_args_add)
+  expect_error(m_hp_wt %>% fitted_samples(newdata = mtcars_tbl, draws = 100),
+               "`tidybayes`*")
+  expect_error(m_hp_wt %>% add_fitted_samples(newdata = mtcars_tbl, draws = 100),
+               "`tidybayes`*")
 })
-

--- a/tests/testthat/test.add_fitted_samples.R
+++ b/tests/testthat/test.add_fitted_samples.R
@@ -125,6 +125,15 @@ test_that("[add_]fitted_samples works on brms models with auxpars", {
   expect_equal(ref %>% select(-sigma), add_fitted_samples(mtcars_tbl, m_hp_sigma, auxpars = NULL))
 })
 
+test_that("[add_]fitted_samples throws an when dpars is called instead of auxpars on brms models with auxpars", {
+  m_hp_sigma = readRDS("models.brms.m_hp_sigma.rds")
+  
+  expect_error(fitted_samples(m_hp_sigma, mtcars_tbl, dpars = "sigma"),
+               "`tidybayes`.*")
+  expect_error(add_fitted_samples(mtcars_tbl, m_hp_sigma, dpars = "sigma"),
+               "`tidybayes`.*")
+})
+
 
 test_that("[add_]fitted_samples works on brms models with categorical outcomes (response scale)", {
   m_cyl_mpg = readRDS("models.brms.m_cyl_mpg.rds")

--- a/tests/testthat/test.add_fitted_samples.R
+++ b/tests/testthat/test.add_fitted_samples.R
@@ -183,3 +183,11 @@ test_that("[add_]predicted_samples throws an error when re.form is called instea
                "`tidybayes`*")
 })
 
+test_that("[add_]predicted_samples throws an error when transform is called instead of scale in rstanarm", {
+  m_hp_wt = readRDS("models.rstanarm.m_hp_wt.rds")
+  
+  expect_error(m_hp_wt %>% fitted_samples(newdata = mtcars_tbl, transform = TRUE),
+               "`tidybayes`*")
+  expect_error(m_hp_wt %>% add_fitted_samples(newdata = mtcars_tbl, transform = TRUE),
+               "`tidybayes`*")
+})

--- a/tests/testthat/test.add_fitted_samples.R
+++ b/tests/testthat/test.add_fitted_samples.R
@@ -167,17 +167,17 @@ test_that("[add_]predicted_samples gives same results with standardized argument
   m_hp = readRDS("models.brms.m_hp.rds")
   
   set.seed(123)
-  std_args_fit <- m_hp %>%
+  std_args_fit = m_hp %>%
     fitted_samples(newdata = mtcars_tbl, n = 100)
   set.seed(123)
-  std_args_add <- m_hp %>%
+  std_args_add = m_hp %>%
     add_fitted_samples(newdata = mtcars_tbl, n = 100)
   
   set.seed(123)
-  predict_args_fit <- m_hp %>%
+  predict_args_fit = m_hp %>%
     fitted_samples(newdata = mtcars_tbl, nsamples = 100)
   set.seed(123)
-  predict_args_add <- m_hp %>%
+  predict_args_add = m_hp %>%
     add_fitted_samples(newdata = mtcars_tbl, nsamples = 100)
   
   expect_equal(nrow(std_args_fit), nrow(predict_args_fit))

--- a/tests/testthat/test.add_predicted_samples.R
+++ b/tests/testthat/test.add_predicted_samples.R
@@ -97,17 +97,17 @@ test_that("[add_]predicted_samples gives same results with standardized argument
   m_hp = readRDS("models.brms.m_hp.rds")
   
   set.seed(123)
-  std_args_pred <- m_hp %>%
+  std_args_pred = m_hp %>%
     predicted_samples(newdata = mtcars_tbl, n = 100)
   set.seed(123)
-  std_args_add <- m_hp %>%
+  std_args_add = m_hp %>%
     add_predicted_samples(newdata = mtcars_tbl, n = 100)
   
   set.seed(123)
-  predict_args_pred <- m_hp %>%
+  predict_args_pred = m_hp %>%
     predicted_samples(newdata = mtcars_tbl, nsamples = 100)
   set.seed(123)
-  predict_args_add <- m_hp %>%
+  predict_args_add = m_hp %>%
     add_predicted_samples(newdata = mtcars_tbl, nsamples = 100)
   
   expect_equal(nrow(std_args_pred), nrow(predict_args_pred))

--- a/tests/testthat/test.add_predicted_samples.R
+++ b/tests/testthat/test.add_predicted_samples.R
@@ -117,3 +117,27 @@ test_that("[add_]predicted_samples gives same results with standardized argument
   expect_equal(std_args_add, predict_args_add)
 })
 
+test_that("[add_]predicted_samples gives same results with standardized arguments and prediction method arguments in rstanarm", {
+  m_hp_wt = readRDS("models.rstanarm.m_hp_wt.rds")
+  
+  set.seed(123)
+  std_args_pred = m_hp_wt %>%
+    predicted_samples(newdata = mtcars_tbl, n = 100)
+  set.seed(123)
+  std_args_add = m_hp_wt %>%
+    add_predicted_samples(newdata = mtcars_tbl, n = 100)
+  
+  set.seed(123)
+  predict_args_pred = m_hp_wt %>%
+    predicted_samples(newdata = mtcars_tbl, nsamples = 100)
+  set.seed(123)
+  predict_args_add = m_hp_wt %>%
+    add_predicted_samples(newdata = mtcars_tbl, nsamples = 100)
+  
+  expect_equal(nrow(std_args_pred), nrow(predict_args_pred))
+  expect_equal(std_args_pred, predict_args_pred)
+  
+  expect_equal(nrow(std_args_add), nrow(predict_args_add))
+  expect_equal(std_args_add, predict_args_add)
+})
+

--- a/tests/testthat/test.add_predicted_samples.R
+++ b/tests/testthat/test.add_predicted_samples.R
@@ -96,27 +96,41 @@ test_that("[add_]predicted_samples works on a simple brms model", {
 test_that("[add_]predicted_samples throws an error when nsamples is called instead of n in brms", {
   m_hp = readRDS("models.brms.m_hp.rds")
 
-  expect_error(m_hp %>% predicted_samples(newdata = mtcars_tbl, nsamples = 100),
-               ".See the documentation for additional details.")
-  expect_error(m_hp %>% add_predicted_samples(newdata = mtcars_tbl, nsamples = 100),
-               ".See the documentation for additional details.")
+  expect_error(
+    m_hp %>% predicted_samples(newdata = mtcars_tbl, nsamples = 100),
+    "`nsamples.*.`n`.*.See the documentation for additional details."
+  )
+  expect_error(
+    m_hp %>% add_predicted_samples(newdata = mtcars_tbl, nsamples = 100),
+    "`nsamples.*.`n`.*.See the documentation for additional details."
+  )
 })
 
 test_that("[add_]predicted_samples throws an error when draws is called instead of n in rstanarm", {
   m_hp_wt = readRDS("models.rstanarm.m_hp_wt.rds")
   
-  expect_error(m_hp_wt %>% predicted_samples(newdata = mtcars_tbl, draws = 100),
-               ".See the documentation for additional details.")
-  expect_error(m_hp_wt %>% add_predicted_samples(newdata = mtcars_tbl, draws = 100),
-               ".See the documentation for additional details.")
+  expect_error(
+    m_hp_wt %>% predicted_samples(newdata = mtcars_tbl, draws = 100),
+    "`draws.*.`n`.*.See the documentation for additional details."
+  )
+  expect_error(
+    m_hp_wt %>% add_predicted_samples(newdata = mtcars_tbl, draws = 100),
+    "`draws.*.`n`.*.See the documentation for additional details."
+  )
 })
 
 test_that("[add_]predicted_samples throws an error when re.form is called instead of re_formula in rstanarm", {
   m_hp_wt = readRDS("models.rstanarm.m_hp_wt.rds")
   
-  expect_error(m_hp_wt %>% predicted_samples(newdata = mtcars_tbl, re.form = NULL),
-               ".See the documentation for additional details.")
-  expect_error(m_hp_wt %>% add_predicted_samples(newdata = mtcars_tbl, re.form = NULL),
-               ".See the documentation for additional details.")
+  expect_error(
+    m_hp_wt %>% predicted_samples(newdata = mtcars_tbl, re.form = NULL),
+    "`re.form.*.`re_formula`.*.See the documentation for additional details."
+  )
+  expect_error(
+    m_hp_wt %>% add_predicted_samples(newdata = mtcars_tbl, re.form = NULL),
+    "`re.form.*.`re_formula`.*.See the documentation for additional details."
+  )
 })
+
+
 

--- a/tests/testthat/test.add_predicted_samples.R
+++ b/tests/testthat/test.add_predicted_samples.R
@@ -97,26 +97,26 @@ test_that("[add_]predicted_samples throws an error when nsamples is called inste
   m_hp = readRDS("models.brms.m_hp.rds")
 
   expect_error(m_hp %>% predicted_samples(newdata = mtcars_tbl, nsamples = 100),
-               "`tidybayes`.*")
+               ".See the documentation for additional details.")
   expect_error(m_hp %>% add_predicted_samples(newdata = mtcars_tbl, nsamples = 100),
-               "`tidybayes`.*")
+               ".See the documentation for additional details.")
 })
 
 test_that("[add_]predicted_samples throws an error when draws is called instead of n in rstanarm", {
   m_hp_wt = readRDS("models.rstanarm.m_hp_wt.rds")
   
   expect_error(m_hp_wt %>% predicted_samples(newdata = mtcars_tbl, draws = 100),
-               "`tidybayes`*")
+               ".See the documentation for additional details.")
   expect_error(m_hp_wt %>% add_predicted_samples(newdata = mtcars_tbl, draws = 100),
-               "`tidybayes`*")
+               ".See the documentation for additional details.")
 })
 
 test_that("[add_]predicted_samples throws an error when re.form is called instead of re_formula in rstanarm", {
   m_hp_wt = readRDS("models.rstanarm.m_hp_wt.rds")
   
   expect_error(m_hp_wt %>% predicted_samples(newdata = mtcars_tbl, re.form = NULL),
-               "`tidybayes`*")
+               ".See the documentation for additional details.")
   expect_error(m_hp_wt %>% add_predicted_samples(newdata = mtcars_tbl, re.form = NULL),
-               "`tidybayes`*")
+               ".See the documentation for additional details.")
 })
 

--- a/tests/testthat/test.add_predicted_samples.R
+++ b/tests/testthat/test.add_predicted_samples.R
@@ -111,3 +111,12 @@ test_that("[add_]predicted_samples throws an error when draws is called instead 
                "`tidybayes`*")
 })
 
+test_that("[add_]predicted_samples throws an error when re.form is called instead of re_formula in rstanarm", {
+  m_hp_wt = readRDS("models.rstanarm.m_hp_wt.rds")
+  
+  expect_error(m_hp_wt %>% predicted_samples(newdata = mtcars_tbl, re.form = NULL),
+               "`tidybayes`*")
+  expect_error(m_hp_wt %>% add_predicted_samples(newdata = mtcars_tbl, re.form = NULL),
+               "`tidybayes`*")
+})
+

--- a/tests/testthat/test.add_predicted_samples.R
+++ b/tests/testthat/test.add_predicted_samples.R
@@ -93,15 +93,6 @@ test_that("[add_]predicted_samples works on a simple brms model", {
   expect_equal(ref, add_predicted_samples(mtcars_tbl, m_hp, seed = 123))
 })
 
-# Test Suite:
-# Test 1: "[add_]predicted_samples gives same results with standardized arguments
-#         "and prediction method arguments in rstanarm"
-# Test 2: "[add_]predicted_samples gives same results with standardized arguments
-#         "and prediction method arguments in brms"
-
-# can't use cmd-shift-t, or devtools::test()
-# need to use testthat::test_package("tidybayes")
-
 test_that("[add_]predicted_samples gives same results with standardized arguments and prediction method arguments in brms", {
   m_hp = readRDS("models.brms.m_hp.rds")
   

--- a/tests/testthat/test.add_predicted_samples.R
+++ b/tests/testthat/test.add_predicted_samples.R
@@ -93,51 +93,21 @@ test_that("[add_]predicted_samples works on a simple brms model", {
   expect_equal(ref, add_predicted_samples(mtcars_tbl, m_hp, seed = 123))
 })
 
-test_that("[add_]predicted_samples gives same results with standardized arguments and prediction method arguments in brms", {
+test_that("[add_]predicted_samples throws an error when nsamples is called instead of n in brms", {
   m_hp = readRDS("models.brms.m_hp.rds")
-  
-  set.seed(123)
-  std_args_pred = m_hp %>%
-    predicted_samples(newdata = mtcars_tbl, n = 100)
-  set.seed(123)
-  std_args_add = m_hp %>%
-    add_predicted_samples(newdata = mtcars_tbl, n = 100)
-  
-  set.seed(123)
-  predict_args_pred = m_hp %>%
-    predicted_samples(newdata = mtcars_tbl, nsamples = 100)
-  set.seed(123)
-  predict_args_add = m_hp %>%
-    add_predicted_samples(newdata = mtcars_tbl, nsamples = 100)
-  
-  expect_equal(nrow(std_args_pred), nrow(predict_args_pred))
-  expect_equal(std_args_pred, predict_args_pred)
-  
-  expect_equal(nrow(std_args_add), nrow(predict_args_add))
-  expect_equal(std_args_add, predict_args_add)
+
+  expect_error(m_hp %>% predicted_samples(newdata = mtcars_tbl, nsamples = 100),
+               "`tidybayes`.*")
+  expect_error(m_hp %>% add_predicted_samples(newdata = mtcars_tbl, nsamples = 100),
+               "`tidybayes`.*")
 })
 
-test_that("[add_]predicted_samples gives same results with standardized arguments and prediction method arguments in rstanarm", {
+test_that("[add_]predicted_samples throws an error when draws is called instead of n in rstanarm", {
   m_hp_wt = readRDS("models.rstanarm.m_hp_wt.rds")
   
-  set.seed(123)
-  std_args_pred = m_hp_wt %>%
-    predicted_samples(newdata = mtcars_tbl, n = 100)
-  set.seed(123)
-  std_args_add = m_hp_wt %>%
-    add_predicted_samples(newdata = mtcars_tbl, n = 100)
-  
-  set.seed(123)
-  predict_args_pred = m_hp_wt %>%
-    predicted_samples(newdata = mtcars_tbl, nsamples = 100)
-  set.seed(123)
-  predict_args_add = m_hp_wt %>%
-    add_predicted_samples(newdata = mtcars_tbl, nsamples = 100)
-  
-  expect_equal(nrow(std_args_pred), nrow(predict_args_pred))
-  expect_equal(std_args_pred, predict_args_pred)
-  
-  expect_equal(nrow(std_args_add), nrow(predict_args_add))
-  expect_equal(std_args_add, predict_args_add)
+  expect_error(m_hp_wt %>% predicted_samples(newdata = mtcars_tbl, draws = 100),
+               "`tidybayes`*")
+  expect_error(m_hp_wt %>% add_predicted_samples(newdata = mtcars_tbl, draws = 100),
+               "`tidybayes`*")
 })
 

--- a/tests/testthat/test.add_predicted_samples.R
+++ b/tests/testthat/test.add_predicted_samples.R
@@ -92,3 +92,37 @@ test_that("[add_]predicted_samples works on a simple brms model", {
   set.seed(123)
   expect_equal(ref, add_predicted_samples(mtcars_tbl, m_hp, seed = 123))
 })
+
+# Test Suite:
+# Test 1: "[add_]predicted_samples gives same results with standardized arguments
+#         "and prediction method arguments in rstanarm"
+# Test 2: "[add_]predicted_samples gives same results with standardized arguments
+#         "and prediction method arguments in brms"
+
+# can't use cmd-shift-t, or devtools::test()
+# need to use testthat::test_package("tidybayes")
+
+test_that("[add_]predicted_samples gives same results with standardized arguments and prediction method arguments in brms", {
+  m_hp = readRDS("models.brms.m_hp.rds")
+  
+  set.seed(123)
+  std_args_pred <- m_hp %>%
+    predicted_samples(newdata = mtcars_tbl, n = 100)
+  set.seed(123)
+  std_args_add <- m_hp %>%
+    add_predicted_samples(newdata = mtcars_tbl, n = 100)
+  
+  set.seed(123)
+  predict_args_pred <- m_hp %>%
+    predicted_samples(newdata = mtcars_tbl, nsamples = 100)
+  set.seed(123)
+  predict_args_add <- m_hp %>%
+    add_predicted_samples(newdata = mtcars_tbl, nsamples = 100)
+  
+  expect_equal(nrow(std_args_pred), nrow(predict_args_pred))
+  expect_equal(std_args_pred, predict_args_pred)
+  
+  expect_equal(nrow(std_args_add), nrow(predict_args_add))
+  expect_equal(std_args_add, predict_args_add)
+})
+


### PR DESCRIPTION
New branch/pull request based off of the conversation in https://github.com/mjskay/tidybayes/pull/96.

For all the standardized arguments listed in issue https://github.com/mjskay/tidybayes/issues/70, I've written error messages and unit tests that expect those errors.

Previously, if a user included an argument that had been standardized, such as `nsamples`, they would get the following error message:
```
Error in predict.brmsfit(model, newdata = newdata, summary = FALSE, ...) : 
   formal argument "nsamples" matched by multiple actual arguments
```
which I found very confusing. 

Now we get this:

 ```
Error in predicted_samples.brmsfit(model, newdata, var, ..., n = n, re_formula = re_formula) : 
  `tidybayes` has standardized some arguments for [add_]predicted_samples Please use `n` rather than `nsamples`. See the documentation for more details. 
```

Let me know your thoughts on wording or anything else.