### PR TITLE
Add option to set seed. Improve docstring

### DIFF
--- a/R/sample_draws.R
+++ b/R/sample_draws.R
@@ -18,8 +18,9 @@
 #' each group.
 #'
 #' @param data Data frame to sample from
-#' @param n The number of draws to select
-#' @param draw The name of the column indexing the draws
+#' @param n The number of draws to select; if not specified it returns all draws.
+#' @param draw The name of the column indexing the draws; default `".draw"`.
+#' @param seed A seed to use when subsampling draws; default `"NULL"` as if no seed had been set.
 #' @author Matthew Kay
 #' @keywords manip
 #' @examples
@@ -53,10 +54,12 @@
 #' }
 #' @importFrom dplyr filter
 #' @export
-sample_draws = function(data, n, draw = ".draw") {
+sample_draws = function(data, n, draw = ".draw", seed = NULL) {
   .draw = as.name(draw)
 
   draw_full = data[[draw]]
+
+  if (!is.null(seed)) set.seed(seed)
 
   draw_sample = sample(unique(draw_full), n)
 


### PR DESCRIPTION
As per #274, add option to set seed when sampling draws with `sample_draws()`.
Also, this PR adds minor changes to the docstring.